### PR TITLE
Quotes In Install Script

### DIFF
--- a/bin/install.sh
+++ b/bin/install.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-[[ -x $(which git) ]] && git submodule update --init --recursive || echo 'You don/'t have git installed, so can/'t update the list'
+[[ -x $(which git) ]] && git submodule update --init --recursive || echo "You don't have git installed, so can't update the list"


### PR DESCRIPTION
If you didn't have Git installed and ran the installer the output would've been:

```
You don/t have git installed, so can/t update the list
```

Using double quotes to wrap the string now gives the output:

```
You don't have git installed, so can't update the list
```
